### PR TITLE
将最终生成结果URL中的 \\ 替换为 /

### DIFF
--- a/fooocusapi/file_utils.py
+++ b/fooocusapi/file_utils.py
@@ -57,4 +57,4 @@ def output_file_to_bytesimg(filename: str | None) -> bytes | None:
 def get_file_serve_url(filename: str | None) -> str | None:
     if filename is None:
         return None
-    return static_serve_base_url + filename
+    return static_serve_base_url + filename.replace('\\', '/')


### PR DESCRIPTION
在Windows上部署时，返回结果中的 filename 格式为 `2023-11-24\\18db27d4-f836-48c9-81a8-ddebf80c6807.png` , 将其替换为 `2023-11-24/18db27d4-f836-48c9-81a8-ddebf80c6807.png` , 替换不会影响原本就是 `/` 格式的字符串

