### PR TITLE
Webhook feature and unique job_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,22 @@ FastAPI powered API for [Fooocus](https://github.com/lllyasviel/Fooocus).
 Currently loaded Fooocus version: [2.1.852](https://github.com/lllyasviel/Fooocus/blob/main/update_log.md).
 
 ### Run with Replicate
+
 Now you can use Fooocus-API by Replicate, the model is on [konieshadow/fooocus-api](https://replicate.com/konieshadow/fooocus-api).
 
 With preset:
-* [konieshadow/fooocus-api-anime](https://replicate.com/konieshadow/fooocus-api-anime)
-* [konieshadow/fooocus-api-realistic](https://replicate.com/konieshadow/fooocus-api-realistic)
+
+- [konieshadow/fooocus-api-anime](https://replicate.com/konieshadow/fooocus-api-anime)
+- [konieshadow/fooocus-api-realistic](https://replicate.com/konieshadow/fooocus-api-realistic)
 
 I believe this is the easiest way to generate image with Fooocus's power.
 
 ### Reuse model files from Fooocus
+
 You can simple copy `config.txt` file from your local Fooocus folder to Fooocus-API's root folder. See [Customization](https://github.com/lllyasviel/Fooocus#customization) for details.
 
 ### Start app
+
 Need python version >= 3.10, or use conda to create a new env.
 
 ```
@@ -27,27 +31,31 @@ conda activate fooocus-api
 ```
 
 Run
+
 ```
 python main.py
 ```
+
 On default, server is listening on 'http://127.0.0.1:8888'
 
-
 ### CMD Flags
-* -h, --help            show this help message and exit
-* --port PORT           Set the listen port, default: 8888
-* --host HOST           Set the listen host, default: 127.0.0.1
-* --base-url BASE_URL   Set base url for outside visit, default is http://host:port
-* --log-level LOG_LEVEL Log info for Uvicorn, default: info
-* --sync-repo SYNC_REPO Sync dependent git repositories to local, 'skip' for skip sync action, 'only' for only do the sync action and not launch app
-* --skip-pip            Skip automatic pip install when setup
-* --preload-pipeline    Preload pipeline before start http server
-* --queue-size QUEUE_SIZE Working queue size, default: 3, generation requests exceeding working queue size will return failure
-* --queue-history QUEUE_HISTORY Finished jobs reserve size, tasks exceeding the limit will be deleted, including output image files, default: 100
+
+- -h, --help show this help message and exit
+- --port PORT Set the listen port, default: 8888
+- --host HOST Set the listen host, default: 127.0.0.1
+- --base-url BASE_URL Set base url for outside visit, default is http://host:port
+- --log-level LOG_LEVEL Log info for Uvicorn, default: info
+- --sync-repo SYNC_REPO Sync dependent git repositories to local, 'skip' for skip sync action, 'only' for only do the sync action and not launch app
+- --skip-pip Skip automatic pip install when setup
+- --preload-pipeline Preload pipeline before start http server
+- --queue-size QUEUE_SIZE Working queue size, default: 3, generation requests exceeding working queue size will return failure
+- --queue-history QUEUE_HISTORY Finished jobs reserve size, tasks exceeding the limit will be deleted, including output image files, default: 100
+- --webhook-url WEBHOOK_URL Webhook url for notify generation result, default: None
 
 Since v0.3.25, added CMD flags support of Fooocus. You can pass any argument which Fooocus supported.
 
 For example, to startup image generation (need more vRAM):
+
 ```
 python main.py --all-in-fp16 --always-gpu
 ```
@@ -55,14 +63,17 @@ python main.py --all-in-fp16 --always-gpu
 For Fooocus CMD flags, see [here](https://github.com/lllyasviel/Fooocus?tab=readme-ov-file#all-cmd-flags).
 
 ### Start with docker
+
 Before use docker with GPU, you should [install NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) first.
 
 Run
+
 ```
 docker run --gpus=all -e NVIDIA_DRIVER_CAPABILITIES=compute,utility -e NVIDIA_VISIBLE_DEVICES=all -p 8888:8888 konieshadow/fooocus-api
 ```
 
 For a more complex usage:
+
 ```
 mkdir ~/repositories
 mkdir -p ~/.cache/pip
@@ -72,17 +83,21 @@ docker run --gpus=all -e NVIDIA_DRIVER_CAPABILITIES=compute,utility -e NVIDIA_VI
     -v ~/.cache/pip:/root/.cache/pip \
     -p 8888:8888 konieshadow/fooocus-api
 ```
+
 It will persistent the dependent repositories and pip cache.
 
 You can add `-e PIP_INDEX_URL={pypi-mirror-url}` to docker run command to change pip index url.
 
 ### Test API
+
 You can open the Swagger Document in "http://127.0.0.1:8888/docs", then click "Try it out" to send a request.
 
 ### Update logs
+
 Please visit [releases](https://github.com/konieshadow/Fooocus-API/releases) page for changes in each version.
 
 ### Completed Apis
+
 Swagger openapi defination see [openapi.json](docs/openapi.json).
 
 You can import it in [Swagger-UI](https://swagger.io/tools/swagger-ui/) editor.
@@ -92,54 +107,70 @@ All the generation api support for response in PNG bytes directly when request's
 All the generation api support async process by pass parameter `async_process` to true. And then use query job api to retrieve progress and generation results.
 
 Break changes from v0.3.25
-* Removed cli argument `disable-private-log`. You can use Fooocus's `--disable-image-log` for the same purpose.
+
+- Removed cli argument `disable-private-log`. You can use Fooocus's `--disable-image-log` for the same purpose.
 
 Break changes from v0.3.24:
-* This version merged Fooocus v2.1.839, which include a seed breaking change. Details for [2.1.839](https://github.com/lllyasviel/Fooocus/blob/main/update_log.md#21839).
+
+- This version merged Fooocus v2.1.839, which include a seed breaking change. Details for [2.1.839](https://github.com/lllyasviel/Fooocus/blob/main/update_log.md#21839).
 
 Break changes from v0.3.16:
-* Parameter format for `loras` has changed for the img2img apis (the multipart/form-data requests). Now it requires JSON string.
+
+- Parameter format for `loras` has changed for the img2img apis (the multipart/form-data requests). Now it requires JSON string.
 
 Break changes from v0.3.0:
-* The generation apis won't return `base64` field unless request parameters set `require_base64` to true.
-* The generation apis return a `url` field where the generated image can be requested via a static file url.
+
+- The generation apis won't return `base64` field unless request parameters set `require_base64` to true.
+- The generation apis return a `url` field where the generated image can be requested via a static file url.
 
 Break changes from v0.3.21:
-* The `seed` field from generation result change to type `String` to avoid numerical overflow.
+
+- The `seed` field from generation result change to type `String` to avoid numerical overflow.
 
 #### Text to Image
+
 > POST /v1/generation/text-to-image
 
 Alternative api for the normal image generation of Fooocus Gradio interface.
 
 #### Image Upscale or Variation
+
 For multipart/form-data request:
+
 > POST /v1/generation/image-upscale-vary
 
 For application/json request:
+
 > POST /v2/generation/image-upscale-vary
 
 Alternative api for 'Upscale or Variation' tab of Fooocus Gradio interface.
 
 #### Image Inpaint or Outpaint
+
 For multipart/form-data request:
+
 > POST /v1/generation/image-inpait-outpaint
 
 For application/json request:
+
 > POST /v2/generation/image-inpait-outpaint
 
 Alternative api for 'Inpaint or Outpaint' tab of Fooocus Gradio interface.
 
 #### Image Prompt
+
 For multipart/form-data request:
+
 > POST /v1/generation/image-prompt
 
 For application/json request:
+
 > POST /v1/generation/image-prompt
 
 Alternative api for 'Image Prompt' tab of Fooocus Gradio interface.
 
 #### Query Job
+
 > GET /v1/generation/query-job
 
 Query async generation request results, return job progress and generation results.
@@ -147,24 +178,29 @@ Query async generation request results, return job progress and generation resul
 You can get preview image of generation steps at current time by this api.
 
 #### Query Job Queue Info
+
 > GET /v1/generation/job-queue
 
 Query job queue info, include running job count, finished job count and last job id.
 
 #### Stop Generation task
+
 > POST /v1/generation/stop
 
 Stop current generation task.
 
 #### Get All Model Names
+
 > GET /v1/engines/all-models
 
 Get all filenames of base model and lora.
 
 #### Refresh Models
+
 > POST /v1/engines/refresh-models
 
 #### Get All Fooocus Styles
+
 > GET /v1/engines/styles
 
 Get all legal Fooocus styles.

--- a/fooocusapi/api_utils.py
+++ b/fooocusapi/api_utils.py
@@ -167,7 +167,7 @@ def generation_output(results: QueueTask | List[ImageGenerationResult], streamin
 
                     job_result = generation_output(task.task_result, False, task_result_require_base64)
         job_step_preview = None if not require_step_preivew else task.task_step_preview
-        return AsyncJobResponse(job_id=task.seq,
+        return AsyncJobResponse(job_id=task.job_id,
                                 job_type=task.type,
                                 job_stage=job_stage,
                                 job_progress=task.finish_progress,

--- a/fooocusapi/base_args.py
+++ b/fooocusapi/base_args.py
@@ -13,3 +13,4 @@ def add_base_args(parser: ArgumentParser, before_prepared: bool):
     parser.add_argument("--preload-pipeline", default=False, action="store_true", help="Preload pipeline before start http server")
     parser.add_argument("--queue-size", type=int, default=3, help="Working queue size, default: 3, generation requests exceeding working queue size will return failure")
     parser.add_argument("--queue-history", type=int, default=100, help="Finished jobs reserve size, tasks exceeding the limit will be deleted, including output image files, default: 100")
+    parser.add_argument('--webhook-url', type=str, default=None, help='The URL to send a POST request when a job is finished')

--- a/fooocusapi/models.py
+++ b/fooocusapi/models.py
@@ -383,12 +383,12 @@ class AsyncJobStage(str, Enum):
 
 
 class QueryJobRequest(BaseModel):
-    job_id: int = Field(description="Job ID to query")
+    job_id: str = Field(description="Job ID to query")
     require_step_preivew: bool = Field(False, description="Set to true will return preview image of generation steps at current time")
 
 
 class AsyncJobResponse(BaseModel):
-    job_id: int = Field(description="Job ID")
+    job_id: str = Field(description="Job ID")
     job_type: TaskType = Field(description="Job type")
     job_stage: AsyncJobStage = Field(description="Job running stage")
     job_progress: int = Field(description="Job running progress, 100 is for finished.")
@@ -400,7 +400,7 @@ class AsyncJobResponse(BaseModel):
 class JobQueueInfo(BaseModel):
     running_size: int = Field(description="The current running and waiting job count")
     finished_size: int = Field(description="Finished job cound (after auto clean)")
-    last_job_id: int = Field(description="Last submit generation job id")
+    last_job_id: str = Field(description="Last submit generation job id")
 
 
 class AllModelNamesResponse(BaseModel):

--- a/fooocusapi/task_queue.py
+++ b/fooocusapi/task_queue.py
@@ -1,8 +1,10 @@
 from enum import Enum
 import time
 import numpy as np
+import uuid
 from typing import List, Tuple
-from fooocusapi.file_utils import delete_output_file
+import requests
+from fooocusapi.file_utils import delete_output_file, get_file_serve_url
 
 from fooocusapi.img_utils import narray_to_base64img
 from fooocusapi.parameters import ImageGenerationResult, GenerationFinishReason
@@ -16,6 +18,7 @@ class TaskType(str, Enum):
 
 
 class QueueTask(object):
+    job_id: str
     is_finished: bool = False
     finish_progress: int = 0
     start_millis: int = 0
@@ -26,8 +29,8 @@ class QueueTask(object):
     task_result: any = None
     error_message: str | None = None
 
-    def __init__(self, seq: int, type: TaskType, req_param: dict, in_queue_millis: int):
-        self.seq = seq
+    def __init__(self, job_id: str, type: TaskType, req_param: dict, in_queue_millis: int):
+        self.job_id = job_id
         self.type = type
         self.req_param = req_param
         self.in_queue_millis = in_queue_millis
@@ -53,55 +56,63 @@ class QueueTask(object):
 class TaskQueue(object):
     queue: List[QueueTask] = []
     history: List[QueueTask] = []
-    last_seq = 0
+    webhook_url: str | None = None
 
-    def __init__(self, queue_size: int, hisotry_size: int):
+    def __init__(self, queue_size: int, hisotry_size: int, webhook_url: str | None = None):
         self.queue_size = queue_size
         self.history_size = hisotry_size
+        self.webhook_url = webhook_url
 
     def add_task(self, type: TaskType, req_param: dict) -> QueueTask | None:
         """
         Create and add task to queue
-        :returns: The created task's seq, or None if reach the queue size limit
+        :returns: The created task's job_id, or None if reach the queue size limit
         """
         if len(self.queue) >= self.queue_size:
             return None
 
-        task = QueueTask(seq=self.last_seq+1, type=type, req_param=req_param,
+        task = QueueTask(job_id=str(uuid.uuid4()), type=type, req_param=req_param,
                          in_queue_millis=int(round(time.time() * 1000)))
         self.queue.append(task)
-        self.last_seq = task.seq
         return task
 
-    def get_task(self, seq: int, include_history: bool = False) -> QueueTask | None:
+    def get_task(self, job_id: str, include_history: bool = False) -> QueueTask | None:
         for task in self.queue:
-            if task.seq == seq:
+            if task.job_id == job_id:
                 return task
 
         if include_history:
             for task in self.history:
-                if task.seq == seq:
+                if task.job_id == job_id:
                     return task
 
         return None
 
-    def is_task_ready_to_start(self, seq: int) -> bool:
-        task = self.get_task(seq)
+    def is_task_ready_to_start(self, job_id: str) -> bool:
+        task = self.get_task(job_id)
         if task is None:
             return False
 
-        return self.queue[0].seq == seq
+        return self.queue[0].job_id == job_id
 
-    def start_task(self, seq: int):
-        task = self.get_task(seq)
+    def start_task(self, job_id: str):
+        task = self.get_task(job_id)
         if task is not None:
             task.start_millis = int(round(time.time() * 1000))
 
-    def finish_task(self, seq: int):
-        task = self.get_task(seq)
+    def finish_task(self, job_id: str):
+        task = self.get_task(job_id)
         if task is not None:
             task.is_finished = True
             task.finish_millis = int(round(time.time() * 1000))
+
+            # Send webhook
+            if task.is_finished and self.webhook_url:
+                data = {
+                    "job_id": task.job_id,
+                    "image_url": get_file_serve_url(task.task_result[0].im) if task.task_result else None
+                }
+                requests.post(self.webhook_url, json=data)
 
             # Move task to history
             self.queue.remove(task)
@@ -114,7 +125,7 @@ class TaskQueue(object):
                     for item in removed_task.task_result:
                         if isinstance(item, ImageGenerationResult) and item.finish_reason == GenerationFinishReason.success and item.im is not None:
                             delete_output_file(item.im)
-                print(f"Clean task history, remove task: {removed_task.seq}")
+                print(f"Clean task history, remove task: {removed_task.job_id}")
 
 
 class TaskOutputs:

--- a/main.py
+++ b/main.py
@@ -263,7 +263,8 @@ def prepare_environments(args) -> bool:
     import fooocusapi.worker as worker
     worker.task_queue.queue_size = args.queue_size
     worker.task_queue.history_size = args.queue_history
-    print(f"[Fooocus-API] Task queue size: {args.queue_size}, queue history size: {args.queue_history}")
+    worker.task_queue.webhook_url = args.webhook_url
+    print(f"[Fooocus-API] Task queue size: {args.queue_size}, queue history size: {args.queue_history}, webhook url: {args.webhook_url}")
 
     if args.gpu_device_id is not None:
         os.environ['CUDA_VISIBLE_DEVICES'] = str(args.gpu_device_id)


### PR DESCRIPTION
Hey there,

I wanted to share some information with you regarding the API. I noticed that when using the async generation function, it requires you to check the system frequently after sending your job. This can be time-consuming and depends on several factors like performance, prompt complexity, and lora usage. Therefore, I implemented a webhook feature that will notify you when the task is completed. 

Additionally, I noticed that there are sequential numbers in the async generation job_id that can create confusion. For example, if your system breaks down on job_id:13 and you have a record on your integrated software with job_id:13, and it's not finished yet, and you check the fooocus-api endpoint with that job_id, it might return you a different image. To solve this, I integrated uuid for job_id to make them unique. This way, if the system breaks down, you won't be able to retrieve the job_id. 

I hope you find this information helpful. If you want to integrate all events, feel free to do so. I don't have enough time to do it myself. 

Thank you.