### PR TITLE
support for store history to db

### DIFF
--- a/examples/examples.ipynb
+++ b/examples/examples.ipynb
@@ -405,6 +405,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import requests\n",
+    "import json\n",
+    "import base64\n",
+    "\n",
     "# text to image with imageprompt 示例\n",
     "host = \"http://127.0.0.1:8888\"\n",
     "image = open(\"./imgs/bear.jpg\", \"rb\").read()\n",

--- a/fooocusapi/base_args.py
+++ b/fooocusapi/base_args.py
@@ -14,3 +14,4 @@ def add_base_args(parser: ArgumentParser, before_prepared: bool):
     parser.add_argument("--queue-size", type=int, default=3, help="Working queue size, default: 3, generation requests exceeding working queue size will return failure")
     parser.add_argument("--queue-history", type=int, default=0, help="Finished jobs reserve size, tasks exceeding the limit will be deleted, including output image files, default: 0, means no limit")
     parser.add_argument('--webhook-url', type=str, default=None, help='The URL to send a POST request when a job is finished')
+    parser.add_argument('--presistent', default=False, action="store_true", help="Store history to db")

--- a/fooocusapi/sql_client.py
+++ b/fooocusapi/sql_client.py
@@ -1,0 +1,205 @@
+import os
+import time
+import platform
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Integer, Float,VARCHAR, Boolean, JSON, Text, create_engine
+from sqlalchemy.orm import declarative_base, Session, Mapped, mapped_column
+
+
+Base = declarative_base()
+
+adv_params_keys = [
+    "disable_preview",
+    "adm_scaler_positive",
+    "adm_scaler_negative",
+    "adm_scaler_end",
+    "adaptive_cfg",
+    "sampler_name",
+    "scheduler_name",
+    "generate_image_grid",
+    "overwrite_step",
+    "overwrite_switch",
+    "overwrite_width",
+    "overwrite_height",
+    "overwrite_vary_strength",
+    "overwrite_upscale_strength",
+    "mixing_image_prompt_and_vary_upscale",
+    "mixing_image_prompt_and_inpaint",
+    "debugging_cn_preprocessor",
+    "skipping_cn_preprocessor",
+    "controlnet_softness",
+    "canny_low_threshold",
+    "canny_high_threshold",
+    "refiner_swap_method",
+    "freeu_enabled",
+    "freeu_b1",
+    "freeu_b2",
+    "freeu_s1",
+    "freeu_s2",
+    "debugging_inpaint_preprocessor",
+    "inpaint_disable_initial_latent",
+    "inpaint_engine",
+    "inpaint_strength",
+    "inpaint_respective_field",
+    "inpaint_mask_upload_checkbox",
+    "invert_mask_checkbox",
+    "inpaint_erode_or_dilate"
+]
+
+if platform.system().lower() == 'windows':
+    default_sqlite_db_path = os.path.join(os.path.dirname(__file__), "../database.db").replace("\\", "/")
+else:
+    default_sqlite_db_path = os.path.join(os.path.dirname(__file__), "../database.db")
+
+connection_uri = os.environ.get("FOOOCUS_DB_CONF", f"sqlite:///{default_sqlite_db_path}")
+
+
+class GenerateRecord(Base):
+    __tablename__ = 'generate_record'
+
+    task_id: Mapped[str] = mapped_column(VARCHAR(255), nullable=False, primary_key=True)
+    task_type: Mapped[str] = mapped_column(Text, nullable=False)
+    result_url: Mapped[str] = mapped_column(Text, nullable=True)
+    finish_reason: Mapped[str] = mapped_column(Text, nullable=True)
+    date_time: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    prompt: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    negative_prompt: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    style_selections: Mapped[Optional[list]] = mapped_column(JSON, nullable=True)
+    performance_selection: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    aspect_ratios_selection: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    base_model_name: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    refiner_model_name: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    refiner_switch: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    loras: Mapped[Optional[list]] = mapped_column(JSON, nullable=True)
+    image_number: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    image_seed: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    sharpness: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    guidance_scale: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    advanced_params: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+
+    input_image: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    input_mask: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    image_prompts: Mapped[Optional[list]] = mapped_column(JSON, nullable=True)
+    inpaint_additional_prompt: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    outpaint_selections: Mapped[Optional[list]] = mapped_column(JSON, nullable=True)
+    outpaint_distance_left: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    outpaint_distance_right: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    outpaint_distance_top: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    outpaint_distance_bottom: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    uov_method: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    upscale_value: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+
+    webhook_url: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    require_base64: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
+    async_process: Mapped[Optional[bool]] = mapped_column(Boolean, nullable=True)
+
+    def __repr__(self) -> str:
+        return f"GenerateRecord(task_id={self.task_id!r}, task_type={self.task_type!r}, \
+                result_url={self.result_url!r}, finish_reason={self.finish_reason!r}, date_time={self.date_time!r}, \
+                prompt={self.prompt!r}, negative_prompt={self.negative_prompt!r}, style_selections={self.style_selections!r}, performance_selection={self.performance_selection!r}, \
+                aspect_ratios_selection={self.aspect_ratios_selection!r}, base_model_name={self.base_model_name!r}, \
+                refiner_model_name={self.refiner_model_name!r}, refiner_switch={self.refiner_switch!r}, loras={self.loras!r}, \
+                image_number={self.image_number!r}, image_seed={self.image_seed!r}, sharpness={self.sharpness!r}, \
+                guidance_scale={self.guidance_scale!r}, advanced_params={self.advanced_params!r}, input_image={self.input_image!r}, \
+                input_mask={self.input_mask!r}, image_prompts={self.image_prompts!r}, inpaint_additional_prompt={self.inpaint_additional_prompt!r}, \
+                outpaint_selections={self.outpaint_selections!r}, outpaint_distance_left={self.outpaint_distance_left!r}, outpaint_distance_right={self.outpaint_distance_right!r}, \
+                outpaint_distance_top={self.outpaint_distance_top!r}, outpaint_distance_bottom={self.outpaint_distance_bottom!r}, uov_method={self.uov_method!r}, \
+                upscale_value={self.upscale_value!r}, webhook_url={self.webhook_url!r}, require_base64={self.require_base64!r}, \
+                async_process={self.async_process!r})"
+
+engine = create_engine(connection_uri)
+
+session = Session(engine)
+Base.metadata.create_all(engine, checkfirst=True)
+session.close()
+
+
+def convert_to_dict_list(obj_list: list[object]) -> dict:
+    dict_list = []
+    for obj in obj_list:
+        # 将对象属性转化为字典键值对
+        dict_obj = {}
+        for attr, value in vars(obj).items():
+            if not callable(value) and not attr.startswith("__") and not attr.startswith("_"):
+                dict_obj[attr] = value
+        task_info = {
+            "task_id": obj.task_id,
+            "task_type": obj.task_type,
+            "result_url": obj.result_url,
+            "finish_reason": obj.finish_reason,
+            "date_time": datetime.fromtimestamp(obj.date_time).strftime("%Y-%m-%d %H:%M:%S"),
+        }
+        del dict_obj['task_id']
+        del dict_obj['task_type']
+        del dict_obj['result_url']
+        del dict_obj['finish_reason']
+        del dict_obj['date_time']
+        dict_list.append({"params": dict_obj, "task_info": task_info})
+    return dict_list
+
+
+
+class MysqlSQLAlchemy:
+    def __init__(self, connection_uri: str):
+        # 'mysql+pymysql://{username}:{password}@{host}:{port}/{database}'
+        self.engine = create_engine(connection_uri)
+        self.session = Session(self.engine)
+
+    def store_history(self, record: dict) -> None:
+        """
+        Store history to database
+        :param record:
+        :return:
+        """
+        self.session.add_all([GenerateRecord(**record)])
+        self.session.commit()
+    
+    def get_history(self, task_id: str=None, page: int=0, page_size: int=20,
+                    order_by: str='date_time') -> list:
+        """
+        Get history from database
+        :param task_id:
+        :return:
+        """
+        if task_id is not None:
+            res = self.session.query(GenerateRecord).filter(GenerateRecord.task_id == task_id).all()
+            if len(res) == 0:
+                return []
+            return convert_to_dict_list(res)
+        
+        res = self.session.query(GenerateRecord).order_by(getattr(GenerateRecord, order_by).desc()).offset(page * page_size).limit(page_size).all()
+        if len(res) == 0:
+            return []
+        return convert_to_dict_list(res)
+
+
+db = MysqlSQLAlchemy(connection_uri=connection_uri)
+def req_to_dict(req: dict) -> dict:
+    req["loras"] = [{"model_name": lora[0], "weight": lora[1]} for lora in req["loras"]]
+    req["advanced_params"] = dict(zip(adv_params_keys, req["advanced_params"]))
+    req["image_prompts"] = [{
+        "cn_img": "",
+        "cn_stop": image[1],
+        "cn_weight": image[2],
+        "cn_type": image[3]
+    } for image in req["image_prompts"]]
+    del req["inpaint_input_image"]
+    del req["uov_input_image"]
+    return req
+
+def add_history(params: dict, task_type: str, task_id: str, result_url: str, finish_reason: str) -> None:
+    params = req_to_dict(params["params"])
+    params["date_time"] = int(time.time())
+    params["task_type"] = task_type
+    params["task_id"] = task_id
+    params["result_url"] = result_url
+    params["finish_reason"] = finish_reason
+
+    db.store_history(params)
+
+
+def query_history(task_id: str=None, page: int=0, page_size: int=20, order_by: str="date_time") -> list:
+    return db.get_history(task_id=task_id, page=page, page_size=page_size, order_by=order_by)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pydantic==2.4.2
 pydantic_core==2.10.1
 python-multipart==0.0.6
 uvicorn[standard]==0.23.2
+sqlalchemy


### PR DESCRIPTION
reuse /v1/generation/job-history to get history from db if you startup with `--presistent` flag
use `http://127.0.0.1:8888/v1/generation/job-history?job_id=03ca7505-e621-4e99-875a-23e4a1753db0` for single job query
page and page_size also support