### PR TITLE
Fix JPEG support

### DIFF
--- a/fooocusapi/utils/file_utils.py
+++ b/fooocusapi/utils/file_utils.py
@@ -51,6 +51,7 @@ def save_output_file(
 
     if extension not in ['png', 'jpg', 'webp']:
         extension = 'png'
+    image_format = Image.registered_extensions()['.'+extension]
 
     if image_meta is None:
         image_meta = {}
@@ -64,7 +65,7 @@ def save_output_file(
     os.makedirs(os.path.dirname(file_path), exist_ok=True)
     Image.fromarray(img).save(
         file_path,
-        format=extension,
+        format=image_format,
         pnginfo=meta,
         optimize=True)
     return Path(filename).as_posix()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ transformers==4.30.2
 safetensors==0.3.1
 accelerate==0.21.0
 pyyaml==6.0
-Pillow==9.2.0
+Pillow==9.4.0
 scipy==1.9.3
 tqdm==4.64.1
 psutil==5.9.5


### PR DESCRIPTION
Currently, at least in my environment, Fooocus-API can't write JPEG format due to errors.
This is because Pillow expects a format specifier for JPEG format as `JPEG` not as `JPG`.

There are at least three possible solutions.

1. Use `jpeg` as format specifier in `Fooocus-API` itself.
   - I think this is the simplest solution but it would be a public API change anyway.
2. Use Image.registered_extensions() to get format specifier, as done in this PR.
   - I think this is the most generic solution.
   - Stable Diffusion webui employs this logic: https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/1c0a0c4c26f78c32095ebc7f8af82f5c04fca8c0/modules/images.py#L570
   - This requires Pillow 9.4.0 due to a weired issue fixed in https://github.com/python-pillow/Pillow/pull/6811
3. Use a literal dictionary like `image_format = {"png":"png", "jpg":"jpeg", "webp":"webp"}.get(extension)`

This PR employs option 2. If this is not aligned with your preference, I will create another PR.