### PR TITLE
feat: add gzip middleware for response compression

### DIFF
--- a/fooocusapi/api.py
+++ b/fooocusapi/api.py
@@ -4,6 +4,7 @@ Entry for startup fastapi server
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 
 import uvicorn
 
@@ -15,6 +16,7 @@ from fooocusapi.routes.query import secure_router as query
 
 app = FastAPI()
 
+app.add_middleware(GZipMiddleware, minimum_size=1000)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],  # Allow access from all sources


### PR DESCRIPTION
This pull request introduces the Gzip compression middleware to our application. Enabling Gzip compression significantly enhances the efficiency of data transmission, especially for our image generation API, which returns images encoded in Base64 format.
<img width="533" alt="image" src="https://github.com/user-attachments/assets/bca4010e-d215-420a-9648-a7334df13a24">
<img width="536" alt="image" src="https://github.com/user-attachments/assets/0617aa4e-4ba0-46af-902c-3f8597afe3fc">
