### PR TITLE
feat: enhance JobHistoryInfo with Task Details and Compatibility Improvements

### DIFF
--- a/fooocusapi/models/common/response.py
+++ b/fooocusapi/models/common/response.py
@@ -61,6 +61,9 @@ class JobHistoryInfo(BaseModel):
     job history info
     """
     job_id: str
+    in_queue_mills: int
+    start_mills: int
+    finish_mills: int
     is_finished: bool = False
 
 

--- a/fooocusapi/routes/query.py
+++ b/fooocusapi/routes/query.py
@@ -89,15 +89,21 @@ def get_history(job_id: str = None, page: int = 0, page_size: int = 20):
     queue = [
         JobHistoryInfo(
             job_id=item.job_id,
-            is_finished=item.is_finished
-        ) for item in worker_queue.queue
+            is_finished=item.is_finished,
+            in_queue_mills=item.in_queue_mills,
+            start_mills=item.start_mills,
+            finish_mills=item.finish_mills,
+        ) for item in worker_queue.queue if not job_id or item.job_id == job_id
     ]
     if not args.persistent:
         history = [
             JobHistoryInfo(
                 job_id=item.job_id,
-                is_finished=item.is_finished
-            ) for item in worker_queue.history
+                is_finished=item.is_finished,
+                in_queue_mills=item.in_queue_mills,
+                start_mills=item.start_mills,
+                finish_mills=item.finish_mills,
+            ) for item in worker_queue.history if not job_id or item.job_id == job_id
         ]
         return JobHistoryResponse(history=history, queue=queue)
 

--- a/fooocusapi/task_queue.py
+++ b/fooocusapi/task_queue.py
@@ -270,8 +270,6 @@ class TaskQueue:
                 from fooocusapi.sql_client import add_history
                 add_history(
                     params=task.req_param.to_dict(),
-                    task_type=task.task_type.value,
-                    task_id=task.job_id,
                     task_info=dict(
                         task_type=task.task_type.value,
                         task_id=task.job_id,

--- a/fooocusapi/task_queue.py
+++ b/fooocusapi/task_queue.py
@@ -268,11 +268,17 @@ class TaskQueue:
             # save history to database
             if self.persistent:
                 from fooocusapi.sql_client import add_history
-
                 add_history(
                     params=task.req_param.to_dict(),
                     task_type=task.task_type.value,
                     task_id=task.job_id,
+                    task_info=dict(
+                        task_type=task.task_type.value,
+                        task_id=task.job_id,
+                        task_in_queue_mills=task.in_queue_mills,
+                        task_start_mills=task.start_mills,
+                        task_finish_mills=task.finish_mills,
+                    ),
                     result_url=",".join([job["url"] for job in data["job_result"]]),
                     finish_reason=task.task_result[0].finish_reason.value,
                 )


### PR DESCRIPTION
# Summary:
This PR introduces new detailed information regarding tasks within the JobHistoryInfo class. Specifically, I've added tracking for three key timestamps related to tasks in the queue: in_queue_mills, start_mills, and finish_mills. This data will be recorded in the database for historical query purposes, benefiting clients by facilitating data analysis and enabling optimization of call frequency control.

# Key Changes:
1. Task Timing Information:

Added fields to capture in_queue_mills, start_mills, and finish_mills for tasks in the queue.
Implemented storage of this data in the database to support historical queries.

2. Backward Compatibility:

To ensure compatibility with previous versions, I've implemented a migration process that updates the table structure on the initial startup of the new version. This allows existing data to be retained and prevents any loss of information.
Bug Fix in Job History API:

Addressed an issue with the /v1/generation/job-history API endpoint, where filtering by job_id did not return a single record as expected. The filtering mechanism has been improved to ensure accurate results.

3. API Compatibility:
Since the changes involve adding new fields without altering the existing API structure, I chose to enhance the current API rather than upgrading it to v2. This allows clients using older versions to seamlessly transition to the new API without needing extensive modifications to their existing code.

# Testing
![img_v3_02dh_cfa89455-1611-4e18-b509-af92d9e2dbbg](https://github.com/user-attachments/assets/07dba736-cdf5-4f57-8edf-2dc4e47455bf)
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/e1f0b8d6-8343-4d3b-9be1-46f2579ad7ad">

![img_v3_02dh_797ac126-27c7-4bef-9528-4a59b814b1bg](https://github.com/user-attachments/assets/48026f5f-6b51-48d2-b004-2da083e96c4d)
![img_v3_02dh_40806d96-505b-49dd-ba92-009efdeeb6cg](https://github.com/user-attachments/assets/80501916-0f24-416b-9b7f-7569eed91aa8)


Feel free to make any adjustments or let me know if you need further changes!