### PR TITLE
Fix: Handle missing  or empty `Accept` header in `/files/{date}/{file_name}` endpoint

### DIFF
--- a/fooocusapi/api.py
+++ b/fooocusapi/api.py
@@ -49,12 +49,18 @@ async def get_output(date: str, file_name: str, accept: str = Header(None)):
     Get a specific output by its ID.
     """
     accept_formats = ('png', 'jpg', 'jpeg', 'webp')
-    try:
-        _, ext = accept.lower().split("/")
+
+    if accept is not None:
+        try:
+            _, ext = accept.lower().split("/")
+            if ext not in accept_formats:
+                ext = None
+        except ValueError:
+            ext = None
+    else:
+        ext = file_name.split('.')[-1]
         if ext not in accept_formats:
             ext = None
-    except ValueError:
-        ext = None
 
     if not file_name.endswith(accept_formats):
         return Response(status_code=404)


### PR DESCRIPTION
#### **Issue**  
The endpoint `/files/{date}/{file_name}` fails with an `AttributeError` when the `Accept` header is not provided (e.g., in a simple `curl` request without headers):  

```python
AttributeError: 'NoneType' object has no attribute 'lower'
```

This occurs because the code assumes `accept` is always present but does not handle cases where it is `None`.  

#### **Changes**  
- Added a check for `accept is not None` before processing the header. 
- Made file extension checks from file name if `accept is None`. 
- set `ext = None` to handle missing/invalid headers gracefully. 

#### **Impact**  
- **Fixes:** Simple requests (e.g., direct browser access or `curl` without headers) now work instead of crashing.  
- **Backward-compatible:** Existing requests with valid `Accept` headers remain unaffected.  

#### **Testing**  
Verified with:  
```bash
# Without Accept header (previously crashed, now returns the original file)
curl --location 'http://127.0.0.1:8888/files/2025-04-14/abe30891-4656-48de-8cab-fd0d25ea6a34-0.png'  \
  -H 'Accept: '

# With Accept header (unchanged behavior)
curl --location 'http://127.0.0.1:8888/files/2025-04-14/abe30891-4656-48de-8cab-fd0d25ea6a34-0.png' \
  -H 'Accept: image/webp'
``` 